### PR TITLE
Hotfix/rpc acl file issue

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -20,7 +20,8 @@ define Package/$(PKG_NAME)
 	TITLE:=LimeApp
 	MAINTAINER:=Marcos Gutierrez <gmarcos@altermundi.net>
 	URL:=http://github.com/libremesh/lime-app
-	DEPENDS:=+uhttpd +uhttpd-mod-ubus +ubus-lime-batman-adv +ubus-lime-bmx6 +ubus-lime-location +ubus-lime-metrics +ubus-lime-metrics +ubus-lime-utils
+	DEPENDS:=+uhttpd +uhttpd-mod-ubus +ubus-lime-batman-adv +ubus-lime-bmx6 \
+		+ubus-lime-location +ubus-lime-metrics +ubus-lime-metrics +ubus-lime-utils
 endef
 
 define Package/$(PKG_NAME)/description
@@ -41,18 +42,7 @@ endef
 
 define Package/$(PKG_NAME)/postinst
 #!/bin/sh
-
-if ! uci show rpcd | grep -q lime-app; then
-	uci add rpcd login
-	uci set rpcd.@login[1].username='lime-app'
-	uci set rpcd.@login[1].password='$1$$ta3C2yX4TvVObdaJyQ9Md1'
-	uci add_list rpcd.@login[1].read='lime-app'
-	uci add_list rpcd.@login[1].write='lime-app'
-	uci commit rpcd
-	/etc/init.d/rpcd restart && /etc/init.d/uhttpd restart
-fi
-
-exit 0
+[ -n "$${IPKG_INSTROOT}" ] ||	( /etc/init.d/rpcd restart && /etc/init.d/uhttpd restart ) || true
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -36,8 +36,8 @@ define Package/$(PKG_NAME)/install
 	$(CP) $(BUILD_DIR)/build/* $(1)/www/app/
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/lime-app.defaults $(1)/etc/uci-defaults/90_lime-app
+	$(INSTALL_BIN) ./files/95-lime-app-rpc-acl $(1)/etc/uci-defaults/
 	@mkdir -p $(1)/usr/share/rpcd/acl.d || true
-	$(INSTALL_BIN) ./files/unauthenticated.json $(1)/usr/share/rpcd/acl.d
 endef
 
 define Package/$(PKG_NAME)/postinst

--- a/packages/lime-app/files/95-lime-app-rpc-acl
+++ b/packages/lime-app/files/95-lime-app-rpc-acl
@@ -1,3 +1,5 @@
+#!/bin/sh
+cat > /usr/share/rpcd/acl.d << EOF
 {
 	"unauthenticated": {
 		"description": "Access controls for unauthenticated requests",
@@ -11,3 +13,4 @@
 		}
 	}
 }
+EOF


### PR DESCRIPTION
The ubus rpc daemon package already contain the rpc-acl so it cannot be
overwritten by lime-app. To fix this, let's do the overwritte on
uci-defaults