### PR TITLE
Update lime-app version

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.1.0-alpha.3
+PKG_VERSION:=v0.1.0-alpha.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=c42733535466bb59a43e6452057e0f4901ec3c3d84dda0d72351f9649883f3db
+PKG_HASH:=582148b14ccde1eabb28cafae85d8cc44232a7e223ad8b0e352b7d0842c7cbb4
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
In these versions the external style sheets (leaflet marker) are loaded on demand and asynchronously. This way the app is not blocked in cases of little or no internet connectivity.

https://github.com/libremesh/lime-app/releases/tag/v0.1.0-alpha.4