### PR TITLE
Lime app v0.2.0

### DIFF
--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -35,7 +35,6 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/app/
-	$(RM) $(BUILD_DIR)/build/*.map
 	$(CP) $(BUILD_DIR)/build/* $(1)/www/app/
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/lime-app.defaults $(1)/etc/uci-defaults/90_lime-app

--- a/packages/lime-app/Makefile
+++ b/packages/lime-app/Makefile
@@ -6,11 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lime-app
-PKG_VERSION:=v0.1.0-alpha.4
+PKG_VERSION:=v0.2.0-alpha.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=582148b14ccde1eabb28cafae85d8cc44232a7e223ad8b0e352b7d0842c7cbb4
+PKG_HASH:=5a03a6630b25afa6b29c1407faeb593f419306e345c538d963abe31a52baac56
 PKG_SOURCE_URL:=https://github.com/libremesh/lime-app/releases/download/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
@@ -35,6 +35,7 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/www/app/
+	$(RM) $(BUILD_DIR)/build/*.map
 	$(CP) $(BUILD_DIR)/build/* $(1)/www/app/
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(INSTALL_BIN) ./files/lime-app.defaults $(1)/etc/uci-defaults/90_lime-app

--- a/packages/lime-app/files/95-lime-app-rpc-acl
+++ b/packages/lime-app/files/95-lime-app-rpc-acl
@@ -1,16 +1,16 @@
 #!/bin/sh
-cat > /usr/share/rpcd/acl.d << EOF
+cat > /usr/share/rpcd/acl.d/unauthenticated.json << EOF
 {
-	"unauthenticated": {
-		"description": "Access controls for unauthenticated requests",
-		"read": {
-			"ubus": {
-				"session": [
-					"access",
-					"login"
-				]
-			}
-		}
-	}
+  "unauthenticated": {
+    "description": "Access controls for unauthenticated requests",
+    "read": {
+      "ubus": {
+        "session": [
+          "access",
+          "login"
+        ]
+      }
+    }
+  }
 }
 EOF

--- a/packages/lime-app/files/lime-app.defaults
+++ b/packages/lime-app/files/lime-app.defaults
@@ -5,4 +5,6 @@ uci set rpcd.@login[1].password='$1$$ta3C2yX4TvVObdaJyQ9Md1'
 uci add_list rpcd.@login[1].read='lime-app'
 uci add_list rpcd.@login[1].write='lime-app'
 uci commit rpcd
+uci set uhttpd.main.ubus_cors='1'
+uci commit uhttpd
 exit 0


### PR DESCRIPTION
Please before doing merge try in "lime-sdk" cooking a firmeware with this version.
--------------------
According to changelog these are the changes since the current version:

**Bug Fixes**

- location: fix inverted value in default location (6fac5dd)
- husky: update hooks in package.json (87ac1ba)
- path: change default path to libremesh lime-app path (53106c0)
- api: fix api call (00dc926)
- cors: fix cors connection (13ef9b5)
- groundrouting: disable groundrouting plugin (e792737)
- package: update leaflet.gridlayer.googlemutant to version 0.7.0 (5be94dd)­
- package: update redux-observable to version 0.19.0 (a941dce)
- package: update redux-observable to version 1.0.0-beta.2 (667aa46)
- reducer: fix wrong state variable (49edbcb)
- redux: use new redux-observable api (f916d61)
- transaltion: fix metrics page transaltions (07969ad)
- translations: remove preact-inline from status component (7668701)
- url: fix ground routing url in menu (78a8263)

**Features**

- align: show message when no other node is found (84a2c1b)
- loading: add loading in ground routing page (1d92b0f)
- location: add new ubus-lime-location api (a32622b)
- location: detect unassigned location in node (e0678a9)
- plugin: init ground routing script (442e934)
- plugin: register groundrouting plugin in config.js (1688639)